### PR TITLE
chore: add repository and changelog URLs to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ requires-python = ">= 3.8"
 [project.urls]
 Homepage = "https://github.com/Ouvill/ai_commit"
 Issues = "https://github.com/Ouvill/ai_commit/issues"
+Repository = "https://github.com/Ouvill/ai_commit"
+Changelog = "https://github.com/Ouvill/ai_commit/blob/main/CHANGELOG.md"
 
 [project.scripts]
 ai-commit = "ai_commit.ai_commit:main"


### PR DESCRIPTION
Added the `Repository` and `Changelog` fields to the `pyproject.toml` file to provide users with links to the project's repository and changelog.